### PR TITLE
Added shortcut to open firefox sidebar straight into Google Tasks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,16 @@
 		"default_title": "Google Tasks",
 		"default_panel": "sidebar.html"
 	},
+
+	"commands": {
+		"_execute_sidebar_action": {
+			"suggested_key": {
+				"default": "Ctrl+Alt+T"
+			},
+		"description": "Open the sidebar for Mini Google Tasks"
+		}
+	},
+
 	"browser_action": {
 		"default_popup": "popup.html",
 		"default_title": "Open Google Tasks",


### PR DESCRIPTION
Default setting is Ctrl+Alt+T (for mac, it is Cmd+Alt+T).
Tested and working.